### PR TITLE
Human-readable serialization for `CorimMap` and associated types

### DIFF
--- a/src/comid.rs
+++ b/src/comid.rs
@@ -1896,6 +1896,7 @@ impl<'a> TriplesMapBuilder<'a> {
 mod tests {
     use super::*;
     use crate::{
+        test::SerdeTestCase,
         triples::{
             ConditionalSeriesRecord, DomainTypeChoice, MeasurementValuesMapBuilder,
             StatefulEnvironmentRecord, SvnTypeChoice,
@@ -1906,58 +1907,36 @@ mod tests {
 
     #[test]
     fn test_comid_role_serde() {
-        struct TestCase {
-            role: ComidRoleTypeChoice,
-            expected_json: &'static str,
-            expected_cbor: Vec<u8>,
-        }
-
-        let test_cases: Vec<TestCase> = vec![
-            TestCase {
-                role: ComidRoleTypeChoice::TagCreator,
+        let test_cases = vec![
+            SerdeTestCase {
+                value: ComidRoleTypeChoice::TagCreator,
                 expected_json: "\"tag-creator\"",
                 expected_cbor: vec![0x00],
             },
-            TestCase {
-                role: ComidRoleTypeChoice::Creator,
+            SerdeTestCase {
+                value: ComidRoleTypeChoice::Creator,
                 expected_json: "\"creator\"",
                 expected_cbor: vec![0x01],
             },
-            TestCase {
-                role: ComidRoleTypeChoice::Maintainer,
+            SerdeTestCase {
+                value: ComidRoleTypeChoice::Maintainer,
                 expected_json: "\"maintainer\"",
                 expected_cbor: vec![0x02],
             },
-            TestCase {
-                role: ComidRoleTypeChoice::Extension(-1),
+            SerdeTestCase {
+                value: ComidRoleTypeChoice::Extension(-1),
                 expected_json: "\"Role(-1)\"",
                 expected_cbor: vec![0x20],
             },
-            TestCase {
-                role: ComidRoleTypeChoice::Extension(1337),
+            SerdeTestCase {
+                value: ComidRoleTypeChoice::Extension(1337),
                 expected_json: "\"Role(1337)\"",
                 expected_cbor: vec![0x19, 0x05, 0x39],
             },
         ];
 
         for tc in test_cases.into_iter() {
-            let actual_json = serde_json::to_string(&tc.role).unwrap();
-
-            assert_eq!(actual_json, tc.expected_json);
-
-            let role_de: ComidRoleTypeChoice = serde_json::from_str(actual_json.as_str()).unwrap();
-
-            assert_eq!(role_de, tc.role);
-
-            let mut actual_cbor: Vec<u8> = vec![];
-            ciborium::into_writer(&tc.role, &mut actual_cbor).unwrap();
-
-            assert_eq!(actual_cbor, tc.expected_cbor);
-
-            let role_de: ComidRoleTypeChoice =
-                ciborium::from_reader(actual_cbor.as_slice()).unwrap();
-
-            assert_eq!(role_de, tc.role);
+            tc.run();
         }
 
         let actual_err = serde_json::from_str::<ComidRoleTypeChoice>("\"foo\"")
@@ -2079,43 +2058,21 @@ mod tests {
 
     #[test]
     fn test_tag_rel_type_choice_serde() {
-        struct TestCase {
-            tag_rel: TagRelTypeChoice,
-            expected_json: &'static str,
-            expected_cbor: Vec<u8>,
-        }
-
-        let test_cases: Vec<TestCase> = vec![
-            TestCase {
-                tag_rel: TagRelTypeChoice::Supplements,
+        let test_cases = vec![
+            SerdeTestCase {
+                value: TagRelTypeChoice::Supplements,
                 expected_json: "\"supplements\"",
                 expected_cbor: vec![0x00],
             },
-            TestCase {
-                tag_rel: TagRelTypeChoice::Replaces,
+            SerdeTestCase {
+                value: TagRelTypeChoice::Replaces,
                 expected_json: "\"replaces\"",
                 expected_cbor: vec![0x01],
             },
         ];
 
         for tc in test_cases.into_iter() {
-            let actual_json = serde_json::to_string(&tc.tag_rel).unwrap();
-
-            assert_eq!(actual_json, tc.expected_json);
-
-            let tag_rel_de: TagRelTypeChoice = serde_json::from_str(actual_json.as_str()).unwrap();
-
-            assert_eq!(tag_rel_de, tc.tag_rel);
-
-            let mut actual_cbor: Vec<u8> = vec![];
-            ciborium::into_writer(&tc.tag_rel, &mut actual_cbor).unwrap();
-
-            assert_eq!(actual_cbor, tc.expected_cbor);
-
-            let tag_rel_de: TagRelTypeChoice =
-                ciborium::from_reader(actual_cbor.as_slice()).unwrap();
-
-            assert_eq!(tag_rel_de, tc.tag_rel);
+            tc.run()
         }
 
         let actual_err = serde_json::from_str::<TagRelTypeChoice>("\"foo\"")

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -1203,6 +1203,7 @@ mod tests {
     use crate::corim::{COSESign1Corim, CorimMetaMap, CorimSignerMap, ProtectedCorimHeaderMap};
     use crate::coswid::{ConciseSwidTag, EntityEntry};
     use crate::numbers::Integer;
+    use crate::test::SerdeTestCase;
     use crate::triples::{
         ClassMap, EnvironmentMap, MeasurementMap, MeasurementValuesMap, ReferenceTripleRecord,
     };
@@ -1506,14 +1507,8 @@ mod tests {
 
     #[test]
     fn test_corim_id_type_choice_serde() {
-        struct TestCase<'a> {
-            value: CorimIdTypeChoice<'a>,
-            expected_cbor: Vec<u8>,
-            expected_json: &'static str,
-        }
-
         let test_cases = vec![
-            TestCase {
+            SerdeTestCase {
                 value: CorimIdTypeChoice::Tstr("foo".into()),
                 expected_cbor: vec![
                     0x63, // tstr(3)
@@ -1521,7 +1516,7 @@ mod tests {
                 ],
                 expected_json: "\"foo\"",
             },
-            TestCase {
+            SerdeTestCase {
                 value: CorimIdTypeChoice::Uuid(
                    UuidType::try_from("550e8400-e29b-41d4-a716-446655440000").unwrap(),
                 ),
@@ -1532,7 +1527,7 @@ mod tests {
                 ],
                 expected_json: "\"550e8400-e29b-41d4-a716-446655440000\"",
             },
-            TestCase {
+            SerdeTestCase {
                 value: CorimIdTypeChoice::Extension(
                    ExtensionValue::Bool(true)
                 ),
@@ -1544,51 +1539,29 @@ mod tests {
         ];
 
         for tc in test_cases.into_iter() {
-            let mut actual_cbor: Vec<u8> = vec![];
-            ciborium::into_writer(&tc.value, &mut actual_cbor).unwrap();
-
-            assert_eq!(actual_cbor, tc.expected_cbor);
-
-            let value_de: CorimIdTypeChoice =
-                ciborium::from_reader(actual_cbor.as_slice()).unwrap();
-
-            assert_eq!(value_de, tc.value);
-
-            let actual_json = serde_json::to_string(&tc.value).unwrap();
-
-            assert_eq!(actual_json, tc.expected_json);
-
-            let value_de: CorimIdTypeChoice = serde_json::from_str(actual_json.as_str()).unwrap();
-
-            assert_eq!(value_de, tc.value);
+            tc.run();
         }
     }
 
     #[test]
     fn test_corim_role_type_choice() {
-        struct TestCase {
-            value: CorimRoleTypeChoice,
-            expected_json: &'static str,
-            expected_cbor: Vec<u8>,
-        }
-
         let test_cases = vec![
-            TestCase {
+            SerdeTestCase {
                 value: CorimRoleTypeChoice::ManifestCreator,
                 expected_json: "\"manifest-creator\"",
                 expected_cbor: vec![ 0x01 ],
             },
-            TestCase {
+            SerdeTestCase {
                 value: CorimRoleTypeChoice::ManifestSigner,
                 expected_json: "\"manifest-signer\"",
                 expected_cbor: vec![ 0x02 ],
             },
-            TestCase {
+            SerdeTestCase {
                 value: CorimRoleTypeChoice::Extension(-1),
                 expected_json: "\"Role(-1)\"",
                 expected_cbor: vec![ 0x20 ],
             },
-            TestCase {
+            SerdeTestCase {
                 value: CorimRoleTypeChoice::Extension(1337),
                 expected_json: "\"Role(1337)\"",
                 expected_cbor: vec![ 0x19, 0x05, 0x39 ],
@@ -1596,23 +1569,7 @@ mod tests {
         ];
 
         for tc in test_cases.into_iter() {
-            let mut actual_cbor: Vec<u8> = vec![];
-            ciborium::into_writer(&tc.value, &mut actual_cbor).unwrap();
-
-            assert_eq!(actual_cbor, tc.expected_cbor);
-
-            let value_de: CorimRoleTypeChoice =
-                ciborium::from_reader(actual_cbor.as_slice()).unwrap();
-
-            assert_eq!(value_de, tc.value);
-
-            let actual_json = serde_json::to_string(&tc.value).unwrap();
-
-            assert_eq!(actual_json, tc.expected_json);
-
-            let value_de: CorimRoleTypeChoice = serde_json::from_str(actual_json.as_str()).unwrap();
-
-            assert_eq!(value_de, tc.value);
+            tc.run();
         }
     }
 

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -646,7 +646,7 @@ impl<'de> Deserialize<'de> for ProfileTypeChoice<'_> {
                                 ciborium::from_reader(buf.as_slice()).map_err(de::Error::custom)?;
                             Ok(ProfileTypeChoice::OidType(oid.into()))
                         }
-                        37 => {
+                        32 => {
                             let uri: Text =
                                 ciborium::from_reader(buf.as_slice()).map_err(de::Error::custom)?;
                             Ok(ProfileTypeChoice::Uri(uri.into()))

--- a/src/error/comid.rs
+++ b/src/error/comid.rs
@@ -5,7 +5,7 @@ use crate::Label;
 #[derive(Debug)]
 pub enum ComidError {
     EmptyTriplesMap,
-    InvalidComidRole(Label<'static>),
+    InvalidComidRole(String),
     InvalidTagRelationship(Label<'static>),
     UnsetMandatoryField(String, String),
     Unknown,

--- a/src/error/corim.rs
+++ b/src/error/corim.rs
@@ -4,6 +4,7 @@
 pub enum CorimError {
     InvalidConciseTagTypeChoice,
     InvalidCorimRole(String),
+    UnsetMandatoryField(String, String),
     Unknown,
 }
 
@@ -17,6 +18,9 @@ impl std::fmt::Display for CorimError {
             }
             Self::InvalidCorimRole(role) => {
                 write!(f, "Invalid CoRIM role \"{role}\"")
+            }
+            Self::UnsetMandatoryField(object, field) => {
+                write!(f, "{object} field(s) {field} must be set")
             }
             Self::Unknown => write!(f, "unknown CorimError encountered"),
         }

--- a/src/error/corim.rs
+++ b/src/error/corim.rs
@@ -4,6 +4,7 @@
 pub enum CorimError {
     InvalidConciseTagTypeChoice,
     InvalidCorimRole(String),
+    InvalidFieldValue(String, String, String),
     UnsetMandatoryField(String, String),
     Unknown,
 }
@@ -18,6 +19,9 @@ impl std::fmt::Display for CorimError {
             }
             Self::InvalidCorimRole(role) => {
                 write!(f, "Invalid CoRIM role \"{role}\"")
+            }
+            Self::InvalidFieldValue(object, field, message) => {
+                write!(f, " invalid {object}.{field} value: {message}")
             }
             Self::UnsetMandatoryField(object, field) => {
                 write!(f, "{object} field(s) {field} must be set")

--- a/src/error/corim.rs
+++ b/src/error/corim.rs
@@ -3,6 +3,7 @@
 #[derive(Debug)]
 pub enum CorimError {
     InvalidConciseTagTypeChoice,
+    InvalidCorimRole(String),
     Unknown,
 }
 
@@ -13,6 +14,9 @@ impl std::fmt::Display for CorimError {
         match self {
             Self::InvalidConciseTagTypeChoice => {
                 write!(f, "Invalid ConciseTagTypeChoice encountered")
+            }
+            Self::InvalidCorimRole(role) => {
+                write!(f, "Invalid CoRIM role \"{role}\"")
             }
             Self::Unknown => write!(f, "unknown CorimError encountered"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,10 @@ pub mod empty;
 /// Provides the Number Traits.
 pub mod numbers;
 
+/// Test utilities
+#[cfg(test)]
+pub(crate) mod test;
+
 // Use all public items from each module
 use comid::*;
 use core::*;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+
+pub(crate) struct SerdeTestCase<T> {
+    pub(crate) value: T,
+    pub(crate) expected_json: &'static str,
+    pub(crate) expected_cbor: Vec<u8>,
+}
+
+impl<'de, T> SerdeTestCase<T>
+where
+    T: Debug + Serialize + DeserializeOwned + Eq,
+{
+    pub(crate) fn run(&self) {
+        let mut actual_cbor: Vec<u8> = vec![];
+        ciborium::into_writer(&self.value, &mut actual_cbor).unwrap();
+
+        assert_eq!(actual_cbor, self.expected_cbor);
+
+        let value_de: T = ciborium::from_reader(actual_cbor.as_slice()).unwrap();
+
+        assert_eq!(value_de, self.value);
+
+        let actual_json = serde_json::to_string(&self.value).unwrap();
+
+        assert_eq!(actual_json, self.expected_json);
+
+        let value_de: T = serde_json::from_str(actual_json.as_str()).unwrap();
+
+        assert_eq!(value_de, self.value);
+    }
+}

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -4251,7 +4251,10 @@ impl<'de, 'a> Deserialize<'de> for ConditionalEndorsementTripleRecord<'a> {
 #[rustfmt::skip::macros(vec)]
 mod test {
     use super::*;
-    use crate::core::{ExtensionValue, HashAlgorithm};
+    use crate::{
+        core::{ExtensionValue, HashAlgorithm},
+        test::SerdeTestCase,
+    };
 
     #[test]
     fn test_class_id_json_serde() {
@@ -5444,19 +5447,13 @@ mod test {
 
     #[test]
     fn test_domain_type_choice_serde() {
-        struct TestCase<'a> {
-            value: DomainTypeChoice<'a>,
-            expected_cbor: Vec<u8>,
-            expected_json: &'static str,
-        }
-
-        let test_cases: Vec<TestCase> = vec! [
-            TestCase{
+        let test_cases = vec! [
+            SerdeTestCase{
                 value: DomainTypeChoice::Uint(1.into()),
                 expected_cbor: vec![0x01],
                 expected_json: "1",
             },
-            TestCase{
+            SerdeTestCase{
                 value: DomainTypeChoice::Text("foo".into()),
                 expected_cbor: vec![
                     0x63, // tstr(3)
@@ -5464,7 +5461,7 @@ mod test {
                 ],
                 expected_json: "\"foo\"",
             },
-            TestCase{
+            SerdeTestCase{
                 value: DomainTypeChoice::Oid("1.2.3.4".try_into().unwrap()),
                 expected_cbor: vec![
                     0xd8, 0x6f, // tag(111) [oid]
@@ -5473,7 +5470,7 @@ mod test {
                 ],
                 expected_json: r#"{"type":"oid","value":"1.2.3.4"}"#,
             },
-            TestCase{
+            SerdeTestCase{
                 value: DomainTypeChoice::Uuid("550e8400-e29b-41d4-a716-446655440000".try_into().unwrap()),
                 expected_cbor: vec![
                     0xd8, 0x25, // tag(37) [uuid]
@@ -5483,7 +5480,7 @@ mod test {
                 ],
                 expected_json: r#"{"type":"uuid","value":"550e8400-e29b-41d4-a716-446655440000"}"#,
             },
-            TestCase{
+            SerdeTestCase{
                 value: DomainTypeChoice::Extension(
                     ExtensionValue::Tag(1337, Box::new(ExtensionValue::Bool(true))),
                 ),
@@ -5496,14 +5493,7 @@ mod test {
         ];
 
         for tc in test_cases.into_iter() {
-            let mut actual_cbor: Vec<u8> = vec![];
-            ciborium::into_writer(&tc.value, &mut actual_cbor).unwrap();
-
-            assert_eq!(actual_cbor, tc.expected_cbor);
-
-            let actual_json = serde_json::to_string(&tc.value).unwrap();
-
-            assert_eq!(actual_json, tc.expected_json);
+            tc.run();
         }
     }
 }


### PR DESCRIPTION
- Human-readalbe serialization for `CorimMap` and its constituent types
- Extension support for `CorimRoleTypeChoice`, `ComidRoleTypeChoice`, and `ComidIdTypeChoice`
- Factor out common test code into `SerdeTestCase` shared across all modules.
- Fix URI deserialization inisde `ProfileTypeChoice`